### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # MCP Fetch
 
+[![smithery badge](https://smithery.ai/badge/@kazuph/mcp-fetch)](https://smithery.ai/server/@kazuph/mcp-fetch)
 Model Context Protocol server for fetching web content and processing images. This allows Claude Desktop (or any MCP client) to fetch web content and handle images appropriately.
 
 <a href="https://glama.ai/mcp/servers/5mknfdhyrg"><img width="380" height="200" src="https://glama.ai/mcp/servers/5mknfdhyrg/badge" alt="@kazuph/mcp-fetch MCP server" /></a>
@@ -45,6 +46,15 @@ The following sections are for those who want to develop or modify the tool.
 
 ## Installation
 
+### Installing via Smithery
+
+To install MCP Fetch for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@kazuph/mcp-fetch):
+
+```bash
+npx -y @smithery/cli install @kazuph/mcp-fetch --client claude
+```
+
+### Manual Installation
 ```bash
 git clone https://github.com/kazuph/mcp-fetch.git
 cd mcp-fetch


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install MCP Fetch for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@kazuph/mcp-fetch

Let me know if any tweaks have to be made!