### PR TITLE
fix: ignore missing downloads directory on startup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1090,7 +1090,7 @@ const IGNORE_ROBOTS_TXT = args.includes("--ignore-robots-txt");
 const server = new Server(
   {
     name: "mcp-fetch",
-    version: "1.6.1",
+    version: "1.6.2",
   },
   {
     capabilities: {

--- a/index.ts
+++ b/index.ts
@@ -91,6 +91,13 @@ function isPrivateIPv6(ip: string): boolean {
   );
 }
 
+function isNodeErrorWithCode(error: unknown): error is NodeJS.ErrnoException {
+  return (
+    error instanceof Error &&
+    typeof (error as NodeJS.ErrnoException).code === "string"
+  );
+}
+
 async function resolveAllIps(hostname: string): Promise<string[]> {
   try {
     const records = await dns.promises.lookup(hostname, {
@@ -401,6 +408,10 @@ async function scanAndRegisterExistingFiles(): Promise<void> {
 
     console.error(`Registered ${imageResources.size} existing image resources`);
   } catch (error) {
+    if (isNodeErrorWithCode(error) && error.code === "ENOENT") {
+      // No downloads directory yet; nothing to register on startup
+      return;
+    }
     console.warn("Failed to scan existing downloads:", error);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kazuph/mcp-fetch",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kazuph/mcp-fetch",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kazuph/mcp-fetch",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "description": "A Model Context Protocol server that provides web content fetching capabilities with automatic image saving and optional AI display",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- guard scanAndRegisterExistingFiles when downloads folder not yet created
- avoid noisy startup warning for ENOENT
- bump package version to 1.6.2

## Testing
- npm run unit
- npm run build

Resolves #10