### PR TITLE
fix: serverInfo version drift (read from package.json) — v1.6.4

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@
 
 import dns from "node:dns";
 import { promises as fs } from "node:fs";
+import { createRequire } from "node:module";
 import net from "node:net";
 import path from "node:path";
 import { URL } from "node:url";
@@ -1067,10 +1068,16 @@ const args = process.argv.slice(2);
 const IGNORE_ROBOTS_TXT = args.includes("--ignore-robots-txt");
 
 // Server setup
+// Read the version from package.json (dist/index.js -> ../package.json) so
+// the serverInfo handshake never drifts from the published npm version.
+const PKG_VERSION: string = createRequire(import.meta.url)(
+  "../package.json"
+).version;
+
 const server = new Server(
   {
     name: "mcp-fetch",
-    version: "1.6.2",
+    version: PKG_VERSION,
   },
   {
     capabilities: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kazuph/mcp-fetch",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kazuph/mcp-fetch",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.0",
@@ -3300,27 +3300,6 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
-    },
-    "node_modules/vite-node/node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
-    "node_modules/vite-node/node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kazuph/mcp-fetch",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "type": "module",
   "description": "A Model Context Protocol server that provides web content fetching capabilities with automatic image saving and optional AI display",
   "main": "dist/index.js",


### PR DESCRIPTION
## Why
The MCP `initialize` handshake advertised `serverInfo.version: "1.6.2"` (hardcoded) while npm is at 1.6.3 — every future release would keep drifting.

## How / What
- Read the version via `createRequire(import.meta.url)("../package.json")` — resolves correctly from `dist/index.js` both in-repo and in the installed npm package
- Bump to **v1.6.4**

## Verification
- `npm test` (unit 4/4 + typecheck + biome): green
- Real stdio handshake now returns `{"name":"mcp-fetch","version":"1.6.4"}`

## Note
Merging this will exercise the repaired npm Trusted Publishing pipeline end-to-end (auto tag → release → publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)